### PR TITLE
fix(renovate): recreate digest updates for same-tag rebuilds

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,6 +70,7 @@
       semanticCommitScope: "{{parentDir}}",
       semanticCommitType: "chore",
       automerge: true,
+      recreateWhen: "always",
     },
     {
       description: "Disable digest pinning for regex managers in Dockerfile",


### PR DESCRIPTION
Adds `recreateWhen: "always"` to the digest packageRule.

Problem: Images like Rust routinely push new digests for the same tag. Renovate tracks that it already handled a digest update for `rust:1.95.0` and disables future automerges, leaving stale PRs like #377.

Fix: `recreateWhen: "always"` tells Renovate to always create a new PR when the digest changes, even if a previous digest PR was automerged.