### PR TITLE
fix: unpin self-referencing workflows and disable renovate for them

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,5 +84,11 @@
       matchFileNames: ["apps/caddy/Dockerfile"],
       pinDigests: false,
     },
+    {
+      description: "Ignore self-referencing reusable workflows (kusold/containers)",
+      matchManagers: ["github-actions"],
+      matchDepNames: ["kusold/containers"],
+      enabled: false,
+    },
   ],
 }

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -17,7 +17,7 @@ jobs:
     secrets: inherit
 
   diff:
-    uses: kusold/containers/.github/workflows/diff.yaml@0b1ffa60dd8000a0d103e5b30a5662ab88f07231 # main
+    uses: kusold/containers/.github/workflows/diff.yaml@main
     # uses: ./.github/workflows/diff.yaml
 
   build-images:

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -13,12 +13,12 @@ concurrency:
 
 jobs:
   diff:
-    uses: kusold/containers/.github/workflows/diff.yaml@0b1ffa60dd8000a0d103e5b30a5662ab88f07231 # main
+    uses: kusold/containers/.github/workflows/diff.yaml@main
 
   build-images:
     needs: ["diff"]
     if: ${{ !contains(needs.diff.outputs.matrix, '[]') }}
-    uses: kusold/containers/.github/workflows/build-images.yaml@0b1ffa60dd8000a0d103e5b30a5662ab88f07231 # main
+    uses: kusold/containers/.github/workflows/build-images.yaml@main
     # uses: ./.github/workflows/build-images.yaml
     secrets: inherit
     with:
@@ -28,7 +28,7 @@ jobs:
   scan-images:
     needs: ["diff", "build-images"]
     if: ${{ !contains(needs.diff.outputs.matrix, '[]') }}
-    uses: kusold/containers/.github/workflows/trivy-scan.yaml@0b1ffa60dd8000a0d103e5b30a5662ab88f07231 # main
+    uses: kusold/containers/.github/workflows/trivy-scan.yaml@main
     secrets: inherit
     permissions:
       contents: read


### PR DESCRIPTION
Removes pinned digests from `kusold/containers` self-referencing reusable workflows and configures Renovate to ignore them.

**Problem:** Every merge to main changes the digest, so Renovate immediately opens a new PR like #397. This creates a perpetual cycle of pointless digest update PRs.

**Changes:**
- Remove pinned digests from `diff.yaml`, `build-images.yaml`, `trivy-scan.yaml` references → use `@main`
- Add Renovate packageRule to disable updates for `kusold/containers` actions
- Includes `recreateWhen: "always"` for Docker digest updates (fixes #377 pattern)